### PR TITLE
Throw an exception when 'narrow' is used with 'conjunction' or 'disjunction'.

### DIFF
--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -187,6 +187,7 @@
         1. Let _localeData_ be %ListFormat%.[[LocaleData]].
         1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. If _style_ is `"narrow"` and _type_ is not `"unit"`, throw a *RangeError* exception.
         1. Let _r_ be ResolveLocale(%ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %ListFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].


### PR DESCRIPTION
Fixes #16.