### PR TITLE
Normalize property retrieval order in Intl.ListFormat for consistency with other Intl service constructors

### DIFF
--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -187,6 +187,7 @@
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be %ListFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %ListFormat%.[[RelevantExtensionKeys]], _localeData_).
+        1. Set _listFormat_.[[Locale]] to _r_.[[locale]].
         1. Let _type_ be ? GetOption(_options_, `"type"`, `"string"`, &laquo; `"conjunction"`, `"disjunction"`, `"unit"` &raquo;, `"conjunction"`).
         1. Set _listFormat_.[[Type]] to _type_.
         1. If _type_ is `"unit"`,
@@ -203,7 +204,6 @@
         1. Set _listFormat_.[[TemplateStart]] to _templates_.[[Start]].
         1. Set _listFormat_.[[TemplateMiddle]] to _templates_.[[Middle]].
         1. Set _listFormat_.[[TemplateEnd]] to _templates_.[[End]].
-        1. Set _listFormat_.[[Locale]] to _r_.[[locale]].
         1. Return _listFormat_.
       </emu-alg>
     </emu-clause>

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -187,9 +187,9 @@
         1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. Let _localeData_ be %ListFormat%.[[LocaleData]].
         1. Let _r_ be ResolveLocale(%ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %ListFormat%.[[RelevantExtensionKeys]], _localeData_).
-        1. Let _type_ be GetOption(_options_, `"type"`, `"string"`, &laquo; `"conjunction"`, `"disjunction"`, `"unit"` &raquo;, `"conjunction"`).
+        1. Let _type_ be ? GetOption(_options_, `"type"`, `"string"`, &laquo; `"conjunction"`, `"disjunction"`, `"unit"` &raquo;, `"conjunction"`).
         1. Set _listFormat_.[[Type]] to _type_.
-        1. Let _style_ be GetOption(_options_, `"style"`, `"string"`, &laquo; `"long"`, `"short"`, `"narrow"` &raquo;, `"long"`).
+        1. Let _style_ be ? GetOption(_options_, `"style"`, `"string"`, &laquo; `"long"`, `"short"`, `"narrow"` &raquo;, `"long"`).
         1. Set _listFormat_.[[Style]] to _style_.
         1. If _style_ is `"narrow"` and _type_ is not `"unit"`, throw a *RangeError* exception.
         1. Let _dataLocale_ be _r_.[[dataLocale]].

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -183,15 +183,15 @@
         1. Else
           1. Let _options_ be ? ToObject(_options_).
         1. Let _opt_ be a new Record.
+        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
+        1. Set _opt_.[[localeMatcher]] to _matcher_.
+        1. Let _localeData_ be %ListFormat%.[[LocaleData]].
+        1. Let _r_ be ResolveLocale(%ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %ListFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Let _type_ be GetOption(_options_, `"type"`, `"string"`, &laquo; `"conjunction"`, `"disjunction"`, `"unit"` &raquo;, `"conjunction"`).
         1. Set _listFormat_.[[Type]] to _type_.
         1. Let _style_ be GetOption(_options_, `"style"`, `"string"`, &laquo; `"long"`, `"short"`, `"narrow"` &raquo;, `"long"`).
         1. Set _listFormat_.[[Style]] to _style_.
-        1. Let _localeData_ be %ListFormat%.[[LocaleData]].
-        1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
-        1. Set _opt_.[[localeMatcher]] to _matcher_.
         1. If _style_ is `"narrow"` and _type_ is not `"unit"`, throw a *RangeError* exception.
-        1. Let _r_ be ResolveLocale(%ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %ListFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _dataLocaleTypes_ be _dataLocaleData_.[[&lt;_type_&gt;]].

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -189,9 +189,12 @@
         1. Let _r_ be ResolveLocale(%ListFormat%.[[AvailableLocales]], _requestedLocales_, _opt_, %ListFormat%.[[RelevantExtensionKeys]], _localeData_).
         1. Let _type_ be ? GetOption(_options_, `"type"`, `"string"`, &laquo; `"conjunction"`, `"disjunction"`, `"unit"` &raquo;, `"conjunction"`).
         1. Set _listFormat_.[[Type]] to _type_.
-        1. Let _style_ be ? GetOption(_options_, `"style"`, `"string"`, &laquo; `"long"`, `"short"`, `"narrow"` &raquo;, `"long"`).
+        1. If _type_ is `"unit"`,
+          1. Let _allowedStyles_ be &laquo; `"long"`, `"short"`, `"narrow"` &raquo;.
+        1. Else,
+          1. Let _allowedStyles_ be &laquo; `"long"`, `"short"` &raquo;.
+        1. Let _style_ be ? GetOption(_options_, `"style"`, `"string"`, _allowedStyles_, `"long"`).
         1. Set _listFormat_.[[Style]] to _style_.
-        1. If _style_ is `"narrow"` and _type_ is not `"unit"`, throw a *RangeError* exception.
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _dataLocaleTypes_ be _dataLocaleData_.[[&lt;_type_&gt;]].


### PR DESCRIPTION
3f2fb50441783142b3e758d9b3a80e071855d95a
- Retrieve "localeMatcher" before other options for consistency with the other Intl service constructors.

adc13dd4d7e187cccdd3fd7bba778ff46fd37c62
- Add missing ? for GetOption calls.

3a29042f480816b739519ece24e7852db98a39b9
- Directly pass the allowed style values to GetOption instead of performing another manual check.

1dfa9df1184e79f06c6311c7f97b6472fe433864
- Set [[Locale]] earlier, also for consistency with the other Intl service constructors.
