### PR TITLE
rollback part of changes in #pull/36

### DIFF
--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -190,11 +190,8 @@
         1. Set _listFormat_.[[Locale]] to _r_.[[locale]].
         1. Let _type_ be ? GetOption(_options_, `"type"`, `"string"`, &laquo; `"conjunction"`, `"disjunction"`, `"unit"` &raquo;, `"conjunction"`).
         1. Set _listFormat_.[[Type]] to _type_.
-        1. If _type_ is `"unit"`,
-          1. Let _allowedStyles_ be &laquo; `"long"`, `"short"`, `"narrow"` &raquo;.
-        1. Else,
-          1. Let _allowedStyles_ be &laquo; `"long"`, `"short"` &raquo;.
-        1. Let _style_ be ? GetOption(_options_, `"style"`, `"string"`, _allowedStyles_, `"long"`).
+        1. Let _style_ be GetOption(_options_, `"style"`, `"string"`, &laquo; `"long"`, `"short"`, `"narrow"` &raquo;, `"long"`).
+        1. If _style_ is `"narrow"` and _type_ is not `"unit"`, throw a *RangeError* exception.
         1. Set _listFormat_.[[Style]] to _style_.
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].


### PR DESCRIPTION
Rollback how we throw the RangeError change in #pull/36 back to the old form so the implementation is possible to attach contextual error message with that RangeError.

Here is more context:

Notice before #pull/36 , the throwing of RangeError of new Intl.ListFormat("en", {style: "narrow"}) is by the 
"
If style is "narrow" and type is not "unit", throw a RangeError exception.
"
which the error message could tell more about what is happening to the user. For example, for V8, the message was
"RangeError: When style is 'narrow', 'unit' is the only allowed value for the type option."
because that is a RangeError for a very specific condition and that that help the developer figure out what happened and can change the course. But in this PR, the throwing of RangeError is throwing inside the
"
Let style be ? GetOption(options, "style", "string", allowedStyles, "long").
"
Since the error is throw inside that, there are no context about the RangeError is connect to the condition of "the type is not "unit"". and therefore the user will see a more generic error message that may mislead them. For example, the error message in v8 we will change to is simply
"
RangeError: Value narrow out of range for Intl.ListFormat options property style
"
which may lead the developer to believe "narrow" is not a valid value for style in any conditions. I suggest we rollback that part to the old way.