### PR TITLE
Normative: tail should be parts instead of Record of parts

### DIFF
--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -87,8 +87,7 @@
           1. Else,
             1. Let _pattern_ be _listFormat_.[[TemplateEnd]].
           1. Let _head_ be a new Record { [[Type]]: `"element"`, [[Value]]: _list_[_i_] }.
-          1. Let _tail_ be a new Record { [[Type]]: `"element"`, [[Value]]: _parts_ }.
-          1. Let _placeables_ be a new Record { [[0]]: _head_, [[1]]: _tail_ }.
+          1. Let _placeables_ be a new Record { [[0]]: _head_, [[1]]: _parts_ }.
           1. Set _parts_ to DeconstructPattern(_pattern_, _placeables_).
           1. Decrement _i_ by 1.
         1. Return _parts_.


### PR DESCRIPTION
Problem:
Right now https://tc39.es/proposal-intl-list-format/#sec-deconstructpattern section `5.g` check if `placeables[part]` is an `List`, and if it is, append the whole list to the end of `results. 

However, https://tc39.es/proposal-intl-list-format/#sec-deconstructpattern section `7.e` initializes `placeables`'s `tail` to be a `Record` with `[[Value]]: parts`, and `parts` gets initialized as `last` in section `5`. 

Therefore, there's a type mismatch here where `placeables[[1]][[Value]]` contains a List of `Part`. It should be that `placeables[[1]]` be the `List` of `Part` itself.

The alternative fix is to change `5.g` in `DescontructPattern` to check if `placables[part][[Value]]` is a `List`.

Reference: https://github.com/zbraniecki/IntlListFormat/blob/master/src/polyfill.js#L95