### PR TITLE
Editorial: Use the PartitionPattern abstract operation.

### DIFF
--- a/spec/biblio.json
+++ b/spec/biblio.json
@@ -29,6 +29,11 @@
       "type": "op",
       "aoid": "SupportedLocales",
       "id": "sec-supportedlocales"
+    },
+    {
+      "type": "op",
+      "aoid": "PartitionPattern",
+      "id": "sec-partitionpattern"
     }
   ]
 }

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -30,29 +30,20 @@
         </pre>
       </p>
       <emu-alg>
+        1. Let _patternParts_ be PartitionPattern(_pattern_).
         1. Let _result_ be a new empty List.
-        1. Let _beginIndex_ be ! Call(%StringProto_indexOf%, _pattern_, &laquo; `"{"`, 0 &raquo;).
-        1. Let _nextIndex_ be 0.
-        1. Let _length_ be the number of code units in _pattern_.
-        1. Repeat, while _beginIndex_ is an integer index into _pattern_
-          1. Let _endIndex_ to ! Call(%StringProto_indexOf%, _pattern_, &laquo; `"}"`, _beginIndex_ &raquo;).
-          1. Assert: _endIndex_ is greater than _beginIndex_.
-          1. If _beginIndex_ is greater than _nextIndex_, then
-            1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
-            1. Append a new Record { [[Type]]: `"literal"`, [[Value]]: _literal_ } as the last element of _result_.
-          1. Let _part_ be the substring of _pattern_ from position _beginIndex_, exclusive, to position _endIndex_, exclusive.
-          1. Assert: _placeables_ has a field [[&lt;_part_&gt;]].
-          1. Let _subst_ be _placeables_.[[&lt;_part_&gt;]].
-          1. If Type(_subst_) is List, then
-            1. For each element _s_ of _subst_ in List order, do
-              1. Append _s_ as the last element of _result_.
+        1. For each element _patternPart_ of _patternParts_, in List order, do
+          1. Let _part_ be _patternPart_.[[Type]].
+          1. If _part_ is `"literal"`, then
+            1. Append Record { [[Type]]: `"literal"`, [[Value]]: _patternPart_.[[Value]] } to _result_.
           1. Else,
-            1. Append _subst_ as the last element of _result_.
-          1. Set _nextIndex_ to _endIndex_ + 1.
-          1. Set _beginIndex_ to ! Call(%StringProto_indexOf%, _pattern_, &laquo; `"{"`, _nextIndex_ &raquo;).
-        1. If _nextIndex_ is less than _length_, then
-          1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, inclusive, to position _length_, exclusive.
-          1. Append a new Record { [[Type]]: `"literal"`, [[Value]]: _literal_ } as the last element of _result_.
+            1. Assert: _placeables_ has a field [[&lt;_part_&gt;]].
+            1. Let _subst_ be _placeables_.[[&lt;_part_&gt;]].
+            1. If Type(_subst_) is List, then
+              1. For each element _s_ of _subst_ in List order, do
+                1. Append _s_ to _result_.
+            1. Else,
+              1. Append _subst_ to _result_.
         1. Return _result_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
This splits the string handling from the actual logic in this algorithm.