### PR TITLE
Fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ lf.format(['Motorcycle', 'Truck' , 'Car']);
 // > "Motorcycle, Truck, and Car"
 ```
 
- >  When style is `narrow`, `unit` is the only allowed value for the type option
-
 
 ### Implementation Status
 


### PR DESCRIPTION
According to https://github.com/tc39/proposal-intl-list-format/issues/42, `style=narrow` is allowed for all types.