### PR TITLE
 Normative: Permit conjunctions to be dependent on preceding and following words

### DIFF
--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -62,7 +62,7 @@
         1. If _size_ is 0, then
           1. Return a new empty List.
         1. If _size_ is 2, then
-          1. Let _pattern_ be _listFormat_.[[TemplatePair]].
+          1. Let _pattern_ be _listFormat_.[[Templates]].[[Pair]].
           1. Let _first_ be a new Record { [[Type]]: `"element"`, [[Value]]: _list_[0] }.
           1. Let _second_ be a new Record { [[Type]]: `"element"`, [[Value]]: _list_[1] }.
           1. Let _placeables_ be a new Record { [[0]]: _first_, [[1]]: _second_ }.
@@ -72,11 +72,11 @@
         1. Let _i_ be _size_ - 2.
         1. Repeat, while _i_ &ge; 0
           1. If _i_ is 0, then
-            1. Let _pattern_ be _listFormat_.[[TemplateStart]].
+            1. Let _pattern_ be _listFormat_.[[Templates]].[[Start]].
           1. Else, if _i_ is less than _size_ - 2, then
-            1. Let _pattern_ be _listFormat_.[[TemplateMiddle]].
+            1. Let _pattern_ be _listFormat_.[[Templates]].[[Middle]].
           1. Else,
-            1. Let _pattern_ be _listFormat_.[[TemplateEnd]].
+            1. Let _pattern_ be _listFormat_.[[Templates]].[[End]].
           1. Let _head_ be a new Record { [[Type]]: `"element"`, [[Value]]: _list_[_i_] }.
           1. Let _placeables_ be a new Record { [[0]]: _head_, [[1]]: _parts_ }.
           1. Set _parts_ to DeconstructPattern(_pattern_, _placeables_).
@@ -166,7 +166,7 @@
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _listFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%ListFormatPrototype%"`, &laquo; [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[TemplatePair]], [[TemplateStart]], [[TemplateMiddle]], [[TemplateEnd]] &raquo;).
+        1. Let _listFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, `"%ListFormatPrototype%"`, &laquo; [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[Templates]] &raquo;).
         1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _options_ is *undefined*, then
           1. Let _options_ be ObjectCreate(*null*).
@@ -185,11 +185,7 @@
         1. Let _dataLocale_ be _r_.[[dataLocale]].
         1. Let _dataLocaleData_ be _localeData_.[[&lt;_dataLocale_&gt;]].
         1. Let _dataLocaleTypes_ be _dataLocaleData_.[[&lt;_type_&gt;]].
-        1. Let _templates_ be _dataLocaleTypes_.[[&lt;_style_&gt;]].
-        1. Set _listFormat_.[[TemplatePair]] to _templates_.[[Pair]].
-        1. Set _listFormat_.[[TemplateStart]] to _templates_.[[Start]].
-        1. Set _listFormat_.[[TemplateMiddle]] to _templates_.[[Middle]].
-        1. Set _listFormat_.[[TemplateEnd]] to _templates_.[[End]].
+        1. Set _listFormat_.[[Templates]] to _dataLocaleTypes_.[[&lt;_style_&gt;]].
         1. Return _listFormat_.
       </emu-alg>
     </emu-clause>
@@ -243,11 +239,15 @@
       </emu-note>
 
       <p>
-        The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints:
+        The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints, for each locale value _locale_ in %ListFormat%.[[AvailableLocales]]:
       </p>
 
       <ul>
-        <li>[[LocaleData]][Locale] must have a `formats` field for all locale values. The value of this field must be a record, which must have fields with the names of the three list formatting types: `conjunction`, `disjunction`, and `unit`. Each record must have fields with the names of three formatting styles: `long`, `short`, and `narrow`. Each of those fields must be records themselves, and each must have fields with names: `Pair`, `Start`, `Middle`, and `End`. Each of those fields must be a template string as specified in LDML List Format Rules.</li>
+        <li>[[LocaleData]][[&lt;_locale_&gt;]] is a Record which has three fields [[conjunction]], [[disjunction]], and [[unit]]. Each of these is a Record which must have fields with the names of three formatting styles: [[long]], [[short]], and [[narrow]].</li>
+        <li>Each of those fields is considered a <dfn>ListFormat template set</dfn>, which must be a Record with the fields with names: [[Pair]], [[Start]], [[Middle]], and [[End]]. Each of those fields must be a template string as specified in LDML List Format Rules.</li>
+        <li>
+          The ListFormat template set Record fields each expected to be valid template patterns.  They should each contain one instance of the substring `"{0}"` and once instance of the substring `"{1}"`, and the substring `"{0}"` should occur before the substring `"{1}"`.
+        </li>
       </ul>
 
       <emu-note>
@@ -383,14 +383,7 @@
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used by the list format styles.</li>
       <li>[[Type]] is one of the String values `"conjunction"`, `"disjunction"`, or `"unit"`, identifying the list of types used.</li>
       <li>[[Style]] is one of the String values `"long"`, `"short"`, or `"narrow"`, identifying the list formatting style used.</li>
-      <li>[[TemplatePair]] is a template for lists of size two. It is expected to be a valid template pattern, as described below.</li>
-      <li>[[TemplateStart]] is a template for lists of size greater than two, to be used at the start of the output. It is expected to be a valid template pattern, as described below.</li>
-      <li>[[TemplateMiddle]] is a template for lists of size greater than two, to be used in the middle of the output. It is expected to be a valid template pattern, as described below.</li>
-      <li>[[TemplateEnd]] is a template for lists of size greater than two, to be used at the end of the output. It is expected to be a valid template pattern, as described below.</li>
+      <li>[[Templates]] is ListFormat template set.</li>
     </ul>
-
-    <p>
-      The four internal slots [[TemplatePair]], [[TemplateStart]], [[TemplateMiddle]], and [[TemplateEnd]] are all expected to be valid template patterns.  They should each contain one instance of the substring `"{0}"` and once instance of the substring `"{1}"`, and the substring `"{0}"` should occur before the substring `"{1}"`.
-    </p>
   </emu-clause>
 </emu-clause>

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -72,7 +72,7 @@
         1. Let _parts_ be &laquo; _last_ &raquo;.
         1. Let _i_ be _size_ - 2.
         1. Repeat, while _i_ &ge; 0
-          1. Let _n_ be an index into _listFormat_.[[Templates]] based on _listFormat_.[[Locale]], _head_, and _parts_.
+          1. Let _n_ be an implementation-defined index into _listFormat_.[[Templates]] based on _listFormat_.[[Locale]], _head_, and _parts_.
           1. If _i_ is 0, then
             1. Let _pattern_ be _listFormat_.[[Templates]][_n_].[[Start]].
           1. Else, if _i_ is less than _size_ - 2, then

--- a/spec/listformat.html
+++ b/spec/listformat.html
@@ -62,7 +62,8 @@
         1. If _size_ is 0, then
           1. Return a new empty List.
         1. If _size_ is 2, then
-          1. Let _pattern_ be _listFormat_.[[Templates]].[[Pair]].
+          1. Let _n_ be an index into _listFormat_.[[Templates]] based on _listFormat_.[[Locale]], _list_[0], and _list_[1].
+          1. Let _pattern_ be _listFormat_.[[Templates]][_n_].[[Pair]].
           1. Let _first_ be a new Record { [[Type]]: `"element"`, [[Value]]: _list_[0] }.
           1. Let _second_ be a new Record { [[Type]]: `"element"`, [[Value]]: _list_[1] }.
           1. Let _placeables_ be a new Record { [[0]]: _first_, [[1]]: _second_ }.
@@ -71,18 +72,23 @@
         1. Let _parts_ be &laquo; _last_ &raquo;.
         1. Let _i_ be _size_ - 2.
         1. Repeat, while _i_ &ge; 0
+          1. Let _n_ be an index into _listFormat_.[[Templates]] based on _listFormat_.[[Locale]], _head_, and _parts_.
           1. If _i_ is 0, then
-            1. Let _pattern_ be _listFormat_.[[Templates]].[[Start]].
+            1. Let _pattern_ be _listFormat_.[[Templates]][_n_].[[Start]].
           1. Else, if _i_ is less than _size_ - 2, then
-            1. Let _pattern_ be _listFormat_.[[Templates]].[[Middle]].
+            1. Let _pattern_ be _listFormat_.[[Templates]][_n_].[[Middle]].
           1. Else,
-            1. Let _pattern_ be _listFormat_.[[Templates]].[[End]].
+            1. Let _pattern_ be _listFormat_.[[Templates]][_n_].[[End]].
           1. Let _head_ be a new Record { [[Type]]: `"element"`, [[Value]]: _list_[_i_] }.
           1. Let _placeables_ be a new Record { [[0]]: _head_, [[1]]: _parts_ }.
           1. Set _parts_ to DeconstructPattern(_pattern_, _placeables_).
           1. Decrement _i_ by 1.
         1. Return _parts_.
       </emu-alg>
+
+      <emu-note>
+        The index _n_ to select across multiple templates permits the conjunction to be dependent on the context, as in Spanish, where "y" or "e" may be selected, dependending on the following word.
+      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-formatlist" aoid="FormatList">
@@ -244,9 +250,9 @@
 
       <ul>
         <li>[[LocaleData]][[&lt;_locale_&gt;]] is a Record which has three fields [[conjunction]], [[disjunction]], and [[unit]]. Each of these is a Record which must have fields with the names of three formatting styles: [[long]], [[short]], and [[narrow]].</li>
-        <li>Each of those fields is considered a <dfn>ListFormat template set</dfn>, which must be a Record with the fields with names: [[Pair]], [[Start]], [[Middle]], and [[End]]. Each of those fields must be a template string as specified in LDML List Format Rules.</li>
+        <li>Each of those fields is considered a <dfn>ListFormat template set</dfn>, which must be List of Records with the fields with names: [[Pair]], [[Start]], [[Middle]], and [[End]]. Each of those fields must be a template string as specified in LDML List Format Rules.</li>
         <li>
-          The ListFormat template set Record fields each expected to be valid template patterns.  They should each contain one instance of the substring `"{0}"` and once instance of the substring `"{1}"`, and the substring `"{0}"` should occur before the substring `"{1}"`.
+          The ListFormat template set's entry's Record fields each expected to be valid template patterns.  They should each contain one instance of the substring `"{0}"` and once instance of the substring `"{1}"`, and the substring `"{0}"` should occur before the substring `"{1}"`.
         </li>
       </ul>
 
@@ -383,7 +389,7 @@
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used by the list format styles.</li>
       <li>[[Type]] is one of the String values `"conjunction"`, `"disjunction"`, or `"unit"`, identifying the list of types used.</li>
       <li>[[Style]] is one of the String values `"long"`, `"short"`, or `"narrow"`, identifying the list formatting style used.</li>
-      <li>[[Templates]] is ListFormat template set.</li>
+      <li>[[Templates]] is a ListFormat template set.</li>
     </ul>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
This change should accommodate Spanish and Italian